### PR TITLE
Rename kafka topic

### DIFF
--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>2.6.0</version>
+            <version>2.4.0</version>
         </dependency>
         <!-- end::kafka[] -->
         <!-- tag::rxjava[] -->

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.3.1</version>
             </plugin>
 
             <!-- Plugin to run unit tests -->

--- a/finish/inventory/pom.xml
+++ b/finish/inventory/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
         </dependency>
         <!-- end::kafka[] -->
         <!-- tag::rxjava[] -->

--- a/finish/inventory/src/main/resources/META-INF/microprofile-config.properties
+++ b/finish/inventory/src/main/resources/META-INF/microprofile-config.properties
@@ -9,7 +9,7 @@ mp.messaging.connector.liberty-kafka.bootstrap.servers=localhost:9093
 mp.messaging.incoming.systemLoad.connector=liberty-kafka
 # end::kafka1[]
 # tag::topic1[]
-mp.messaging.incoming.systemLoad.topic=systemLoadTopic
+mp.messaging.incoming.systemLoad.topic=system.load
 # end::topic1[]
 # tag::deserializer1[]
 mp.messaging.incoming.systemLoad.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
@@ -28,7 +28,7 @@ mp.messaging.incoming.systemLoad.group.id=system-load-status
 mp.messaging.incoming.addSystemProperty.connector=liberty-kafka
 # end::kafka3[]
 # tag::topic3[]
-mp.messaging.incoming.addSystemProperty.topic=addSystemPropertyTopic
+mp.messaging.incoming.addSystemProperty.topic=add.system.property
 # end::topic3[]
 # tag::deserializer3[]
 mp.messaging.incoming.addSystemProperty.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
@@ -47,7 +47,7 @@ mp.messaging.incoming.addSystemProperty.group.id=sys-property
 mp.messaging.outgoing.requestSystemProperty.connector=liberty-kafka
 # end::kafka4[]
 # tag::topic4[]
-mp.messaging.outgoing.requestSystemProperty.topic=requestSystemPropertyTopic
+mp.messaging.outgoing.requestSystemProperty.topic=request.system.property
 # end::topic4[]
 # tag::serializer4[]
 mp.messaging.outgoing.requestSystemProperty.key.serializer=org.apache.kafka.common.serialization.StringSerializer

--- a/finish/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryServiceIT.java
+++ b/finish/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryServiceIT.java
@@ -58,7 +58,7 @@ public class InventoryServiceIT {
 
     @KafkaConsumerClient(valueDeserializer = StringDeserializer.class,
             groupId = "property-name",
-            topics = "requestSystemPropertyTopic",
+            topics = "request.system.property",
             properties = ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "=earliest")
     public static KafkaConsumer<String, String> propertyConsumer;
 
@@ -70,7 +70,7 @@ public class InventoryServiceIT {
     @Test
     public void testCpuUsage() throws InterruptedException {
         SystemLoad sl = new SystemLoad("localhost", 1.1);
-        producer.send(new ProducerRecord<String, SystemLoad>("systemLoadTopic", sl));
+        producer.send(new ProducerRecord<String, SystemLoad>("system.load", sl));
         Thread.sleep(5000);
         Response response = inventoryResource.getSystems();
         List<Properties> systems =

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
         </dependency>
         <!-- end::kafka[] -->
         <!-- tag::rxjava[] -->

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -100,7 +100,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.3.1</version>
             </plugin>
 
             <!-- Plugin to run unit tests -->

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -46,13 +46,13 @@
         <dependency>
             <groupId>io.openliberty.guides</groupId>
             <artifactId>models</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0-SNAPSHOT</version>    
         </dependency>
         <!-- tag::kafka[] -->
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>2.6.0</version>
+            <version>2.4.0</version>
         </dependency>
         <!-- end::kafka[] -->
         <!-- tag::rxjava[] -->

--- a/finish/system/src/main/resources/META-INF/microprofile-config.properties
+++ b/finish/system/src/main/resources/META-INF/microprofile-config.properties
@@ -9,7 +9,7 @@ mp.messaging.connector.liberty-kafka.bootstrap.servers=localhost:9093
 mp.messaging.outgoing.systemLoad.connector=liberty-kafka
 # end::kafka1[]
 # tag::topic1[]
-mp.messaging.outgoing.systemLoad.topic=systemLoadTopic
+mp.messaging.outgoing.systemLoad.topic=system.load
 # end::topic1[]
 # tag::serializer1[]
 mp.messaging.outgoing.systemLoad.key.serializer=org.apache.kafka.common.serialization.StringSerializer
@@ -25,7 +25,7 @@ mp.messaging.outgoing.systemLoad.value.serializer=io.openliberty.guides.models.S
 mp.messaging.outgoing.propertyResponse.connector=liberty-kafka
 # end::kafka3[]
 # tag::topic3[]
-mp.messaging.outgoing.propertyResponse.topic=addSystemPropertyTopic
+mp.messaging.outgoing.propertyResponse.topic=add.system.property
 # end::topic3[]
 # tag::serializer3[]
 mp.messaging.outgoing.propertyResponse.key.serializer=org.apache.kafka.common.serialization.StringSerializer
@@ -41,7 +41,7 @@ mp.messaging.outgoing.propertyResponse.value.serializer=io.openliberty.guides.mo
 mp.messaging.incoming.propertyRequest.connector=liberty-kafka
 # end::kafka4[]
 # tag::topic4[]
-mp.messaging.incoming.propertyRequest.topic=requestSystemPropertyTopic
+mp.messaging.incoming.propertyRequest.topic=request.system.property
 # end::topic4[]
 # tag::deserializer4[]
 mp.messaging.incoming.propertyRequest.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer

--- a/finish/system/src/test/java/it/io/openliberty/guides/system/SystemServiceIT.java
+++ b/finish/system/src/test/java/it/io/openliberty/guides/system/SystemServiceIT.java
@@ -43,13 +43,13 @@ public class SystemServiceIT {
 
     @KafkaConsumerClient(valueDeserializer = SystemLoadDeserializer.class,
             groupId = "system-load-status",
-            topics = "systemLoadTopic",
+            topics = "system.load",
             properties = ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "=earliest")
     public static KafkaConsumer<String, SystemLoad> consumer;
 
     @KafkaConsumerClient(valueDeserializer = PropertyMessageDeserializer.class,
             groupId = "property-name",
-            topics = "addSystemPropertyTopic",
+            topics = "add.system.property",
             properties = ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "=earliest")
     public static KafkaConsumer<String, PropertyMessage> propertyConsumer;
 
@@ -74,7 +74,7 @@ public class SystemServiceIT {
 
     @Test
     public void testPropertyMessage() throws IOException, InterruptedException {
-        propertyProducer.send(new ProducerRecord<String, String>("requestSystemPropertyTopic", "os.name"));
+        propertyProducer.send(new ProducerRecord<String, String>("request.system.property", "os.name"));
 
         ConsumerRecords<String, PropertyMessage> records =
                 propertyConsumer.poll(Duration.ofMillis(30 * 1000));

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>2.6.0</version>
+            <version>2.4.0</version>
         </dependency>
         <!-- end::kafka[] -->
         <!-- tag::rxjava[] -->

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -105,7 +105,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.3.1</version>
             </plugin>
 
             <!-- Plugin to run unit tests -->

--- a/start/inventory/pom.xml
+++ b/start/inventory/pom.xml
@@ -57,7 +57,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
         </dependency>
         <!-- end::kafka[] -->
         <!-- tag::rxjava[] -->

--- a/start/inventory/src/main/resources/META-INF/microprofile-config.properties
+++ b/start/inventory/src/main/resources/META-INF/microprofile-config.properties
@@ -3,7 +3,7 @@ mp.messaging.connector.liberty-kafka.bootstrap.servers=localhost:9093
 
 # systemLoad stream
 mp.messaging.incoming.systemLoad.connector=liberty-kafka
-mp.messaging.incoming.systemLoad.topic=systemLoadTopic
+mp.messaging.incoming.systemLoad.topic=system.load
 mp.messaging.incoming.systemLoad.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
 mp.messaging.incoming.systemLoad.value.deserializer=io.openliberty.guides.models.SystemLoad$SystemLoadDeserializer
 mp.messaging.incoming.systemLoad.group.id=system-load-status

--- a/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryServiceIT.java
+++ b/start/inventory/src/test/java/it/io/openliberty/guides/inventory/InventoryServiceIT.java
@@ -58,7 +58,7 @@ public class InventoryServiceIT {
 
     @KafkaConsumerClient(valueDeserializer = StringDeserializer.class,
             groupId = "property-name",
-            topics = "requestSystemPropertyTopic",
+            topics = "request.system.property",
             properties = ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "=earliest")
     public static KafkaConsumer<String, String> propertyConsumer;
 
@@ -70,7 +70,7 @@ public class InventoryServiceIT {
     @Test
     public void testCpuUsage() throws InterruptedException {
         SystemLoad sl = new SystemLoad("localhost", 1.1);
-        producer.send(new ProducerRecord<String, SystemLoad>("systemLoadTopic", sl));
+        producer.send(new ProducerRecord<String, SystemLoad>("system.load", sl));
         Thread.sleep(5000);
         Response response = inventoryResource.getSystems();
         List<Properties> systems =

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>2.6.0</version>
+            <version>2.4.0</version>
         </dependency>
         <!-- end::kafka[] -->
         <!-- tag::rxjava[] -->

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -52,7 +52,7 @@
         <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>kafka-clients</artifactId>
-            <version>2.4.0</version>
+            <version>2.6.0</version>
         </dependency>
         <!-- end::kafka[] -->
         <!-- tag::rxjava[] -->

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -100,7 +100,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.2</version>
+                <version>3.3.1</version>
             </plugin>
 
             <!-- Plugin to run unit tests -->

--- a/start/system/src/main/resources/META-INF/microprofile-config.properties
+++ b/start/system/src/main/resources/META-INF/microprofile-config.properties
@@ -3,6 +3,6 @@ mp.messaging.connector.liberty-kafka.bootstrap.servers=localhost:9093
 
 # systemLoad stream
 mp.messaging.outgoing.systemLoad.connector=liberty-kafka
-mp.messaging.outgoing.systemLoad.topic=systemLoadTopic
+mp.messaging.outgoing.systemLoad.topic=system.load
 mp.messaging.outgoing.systemLoad.key.serializer=org.apache.kafka.common.serialization.StringSerializer
 mp.messaging.outgoing.systemLoad.value.serializer=io.openliberty.guides.models.SystemLoad$SystemLoadSerializer

--- a/start/system/src/test/java/it/io/openliberty/guides/system/SystemServiceIT.java
+++ b/start/system/src/test/java/it/io/openliberty/guides/system/SystemServiceIT.java
@@ -43,13 +43,13 @@ public class SystemServiceIT {
 
     @KafkaConsumerClient(valueDeserializer = SystemLoadDeserializer.class,
             groupId = "system-load-status",
-            topics = "systemLoadTopic",
+            topics = "system.load",
             properties = ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "=earliest")
     public static KafkaConsumer<String, SystemLoad> consumer;
 
     @KafkaConsumerClient(valueDeserializer = PropertyMessageDeserializer.class,
             groupId = "property-name",
-            topics = "addSystemPropertyTopic",
+            topics = "add.system.property",
             properties = ConsumerConfig.AUTO_OFFSET_RESET_CONFIG + "=earliest")
     public static KafkaConsumer<String, PropertyMessage> propertyConsumer;
 
@@ -74,7 +74,7 @@ public class SystemServiceIT {
 
     @Test
     public void testPropertyMessage() throws IOException, InterruptedException {
-        propertyProducer.send(new ProducerRecord<String, String>("requestSystemPropertyTopic", "os.name"));
+        propertyProducer.send(new ProducerRecord<String, String>("request.system.property", "os.name"));
 
         ConsumerRecords<String, PropertyMessage> records =
                 propertyConsumer.poll(Duration.ofMillis(30 * 1000));


### PR DESCRIPTION
Addressing https://github.com/OpenLiberty/guides-common/issues/536

Renamed the following topics:

`systemLoadTopic` --> `system.load`
`addSystemPropertyTopic` --> `add.system.property`
`requestSystemPropertyTopic` --> `request.system.property`

